### PR TITLE
Update documentation to allow link clicking

### DIFF
--- a/R/use_rstudio_prefs.R
+++ b/R/use_rstudio_prefs.R
@@ -3,7 +3,7 @@
 #' This function updates the RStudio preferences saved in
 #' the `rstudio-prefs.json` file. A full listing of preferences that may be
 #' modified are listed here
-#' https://docs.rstudio.com/ide/server-pro/session-user-settings.html
+#' \url{https://docs.rstudio.com/ide/server-pro/session-user-settings.html}
 #'
 #' @param ... series of RStudio preferences to update, e.g.
 #' `always_save_history = FALSE, rainbow_parentheses = TRUE`

--- a/man/rstudio.prefs-package.Rd
+++ b/man/rstudio.prefs-package.Rd
@@ -6,13 +6,7 @@
 \alias{rstudio.prefs-package}
 \title{rstudio.prefs: Set 'RStudio' Preferences}
 \description{
-As of 'RStudio' v1.3, the preferences in the Global Options
-    dialog (and a number of other preferences that aren’t) are now saved
-    in simple, plain-text JSON files. This package provides an interface
-    for working with these 'RStudio' JSON preference files to easily make
-    modifications without using the point-and-click option menus. This is
-    particularly helpful when working on teams to ensure a unified
-    experience across machines and utilizing settings for best practices.
+As of 'RStudio' v1.3, the preferences in the Global Options dialog (and a number of other preferences that aren’t) are now saved in simple, plain-text JSON files. This package provides an interface for working with these 'RStudio' JSON preference files to easily make modifications without using the point-and-click option menus. This is particularly helpful when working on teams to ensure a unified experience across machines and utilizing settings for best practices.
 }
 \seealso{
 Useful links:

--- a/man/use_rstudio_prefs.Rd
+++ b/man/use_rstudio_prefs.Rd
@@ -25,7 +25,7 @@ NULL, updates RStudio \code{rstudio-prefs.json} file
 This function updates the RStudio preferences saved in
 the \code{rstudio-prefs.json} file. A full listing of preferences that may be
 modified are listed here
-https://docs.rstudio.com/ide/server-pro/session-user-settings.html
+\url{https://docs.rstudio.com/ide/server-pro/session-user-settings.html}
 }
 \examples{
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/renv.lock
+++ b/renv.lock
@@ -81,10 +81,10 @@
     },
     "desc": {
       "Package": "desc",
-      "Version": "1.3.0",
+      "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b6963166f7f10b970af1006c462ce6cd"
+      "Hash": "28763d08fadd0b733e3cee9dab4e12fe"
     },
     "diffobj": {
       "Package": "diffobj",
@@ -95,10 +95,10 @@
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.27",
+      "Version": "0.6.28",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a0cbe758a531d054b537d16dff4d58a1"
+      "Hash": "49b5c6e230bfec487b8917d5a0c77cca"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -179,10 +179,10 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.34",
+      "Version": "1.36",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "aa958054ac6f0360926bb952ea302f0f"
+      "Hash": "46344b93f8854714cdf476433a59ed10"
     },
     "lazyeval": {
       "Package": "lazyeval",
@@ -193,10 +193,10 @@
     },
     "lifecycle": {
       "Package": "lifecycle",
-      "Version": "1.0.0",
+      "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3471fb65971f1a7b2d4ae7848cf2db8d"
+      "Hash": "a6b6d352e3ed897373ab19d8395c98d0"
     },
     "magrittr": {
       "Package": "magrittr",
@@ -207,10 +207,10 @@
     },
     "mime": {
       "Package": "mime",
-      "Version": "0.11",
+      "Version": "0.12",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8974a907200fc9948d636fe7d85ca9fb"
+      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
     },
     "openssl": {
       "Package": "openssl",
@@ -221,10 +221,10 @@
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.6.2",
+      "Version": "1.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "43f228eb4b49093d1c8a5c93cae9efe9"
+      "Hash": "3323bc1a0988d63b5c65771ba0d3935d"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -368,10 +368,10 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.4",
+      "Version": "3.1.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5e8ad5621e5c94b24ec07b88eee13df8"
+      "Hash": "36eb05ad4cfdfeaa56f5a9b2a1311efd"
     },
     "tidyselect": {
       "Package": "tidyselect",


### PR DESCRIPTION
When viewing documentation after running `?rstudio.prefs::use_rstudio_prefs`, this link to all the configurations was not clickable. Making the link clickable will make accessing this list much easier for users.