### PR TITLE
Empty repo fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rstudio.prefs
 Title: Set 'RStudio' Preferences
-Version: 0.1.8.9000
+Version: 0.1.8.9001
 Authors@R: 
     person(given = "Daniel D.",
            family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rstudio.prefs (development version)
 
+* Fix for `use_rstudio_secondary_repo()` when it is used to set the first secondary repository. (#14)
+
 # rstudio.prefs 0.1.8
 
 * Updated URL where RStudio preferences are downloaded from in `fetch_rstudio_prefs()`.

--- a/R/add_ins.R
+++ b/R/add_ins.R
@@ -17,7 +17,7 @@
 #' * NOTE: It is possible to override a previously specified key combination with this selection.
 #' @seealso [fs::path_norm]
 #' @export
-#' @returns normalized path string
+#' @return normalized path string
 #' @examples
 #' if (interactive()) {
 #'   # set a keyboard shortcut for path normalization

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -3,7 +3,10 @@ pretty_print_updates <- function(old, new) {
   df_updates <-
     # data frame of old prefs
     tibble::tibble(
-      pref = names(old) %>% intersect(names(new)),
+      pref =
+        names(old) %>%
+        intersect(names(new)) %||%
+        character(0), # if no overlap with old and new, drop in a placeholder,
       old_value =
         old[names(old) %>% intersect(names(new))] %>%
         unname() %>% lapply(as.character) %>% unlist() %||%

--- a/R/use_rstudio_keyboard_shortcut.R
+++ b/R/use_rstudio_keyboard_shortcut.R
@@ -9,7 +9,7 @@
 #' @inheritParams use_rstudio_prefs
 #'
 #' @export
-#' @returns NULL, updates RStudio `addins.json` file
+#' @return NULL, updates RStudio `addins.json` file
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()
@@ -91,7 +91,6 @@ use_rstudio_keyboard_shortcut <- function(..., .write_json = TRUE, .backup = TRU
 #' have been switched.
 #' @param x named list
 #'
-#' @return
 #' @keywords internal
 #' @noRd
 invert_list_names_and_values <- function(x) {

--- a/R/use_rstudio_prefs.R
+++ b/R/use_rstudio_prefs.R
@@ -15,7 +15,7 @@
 #' file before it's updated. Default is `TRUE`
 #'
 #' @export
-#' @returns NULL, updates RStudio `rstudio-prefs.json` file
+#' @return NULL, updates RStudio `rstudio-prefs.json` file
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()

--- a/R/use_rstudio_secondary_repo.R
+++ b/R/use_rstudio_secondary_repo.R
@@ -15,7 +15,7 @@
 #' @inheritParams use_rstudio_prefs
 #'
 #' @export
-#' @returns NULL, updates RStudio `rstudio-prefs.json` file
+#' @return NULL, updates RStudio `rstudio-prefs.json` file
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()
@@ -112,7 +112,7 @@ use_rstudio_secondary_repo <- function(..., .write_json = TRUE, .backup = TRUE) 
 #' @param x secondary repository string from
 #' `"rstudio-prefs.json"` --> `"cran_mirror"` --> `"secondary"`
 #' @export
-#' @returns named list
+#' @return named list
 #' @author Daniel D. Sjoberg
 #'
 #' @examples

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@
 #'
 #' @param version string of min required version number
 #' @export
-#' @returns path string to RStudio `rstudio-prefs.json` file
+#' @return path string to RStudio `rstudio-prefs.json` file
 #' @author Daniel D. Sjoberg
 #'
 #' @examples
@@ -25,7 +25,7 @@ check_min_rstudio_version <- function(version) {
 #' @param ... strings added to the RStudio config path
 #'
 #' @export
-#' @returns path string to RStudio `rstudio-prefs.json` file
+#' @return path string to RStudio `rstudio-prefs.json` file
 #' @author Daniel D. Sjoberg
 #'
 #' @examples


### PR DESCRIPTION
* Fix for `use_rstudio_secondary_repo()` when it is used to set the first secondary repository. 

closes #14